### PR TITLE
fix hidden HUD CPU usage

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -76,6 +76,18 @@ let project = Project(
                 "DEVELOPMENT_TEAM": "Q8H6GWJ658",
                 "CODE_SIGN_IDENTITY": "Apple Development",
             ])
-        )
+        ),
+        .target(
+            name: "MurmurTests",
+            destinations: .macOS,
+            product: .unitTests,
+            bundleId: "app.bshk.murmur.tests",
+            deploymentTargets: .macOS("15.0"),
+            sources: ["Tests/MurmurTests/**/*.swift"],
+            dependencies: [.target(name: "Murmur")],
+            settings: .settings(base: [
+                "SWIFT_VERSION": "5.0",
+            ])
+        ),
     ]
 )

--- a/Sources/Murmur/HUDOverlay.swift
+++ b/Sources/Murmur/HUDOverlay.swift
@@ -214,12 +214,14 @@ final class HUDController {
     private let model = HUDModel()
     private var panel: NSPanel?
     private var hideWork: DispatchWorkItem?
+    private var presentationID = 0
     private let size = NSSize(width: 940, height: 260)
 
     /// Reveal the HUD for a new utterance. `interactive` (toggle mode) makes the
     /// panel accept clicks so the Stop button works.
     func begin(presentation: Bool, lang: String, interactive: Bool = false, onStop: @escaping () -> Void = {}) {
         hideWork?.cancel(); hideWork = nil
+        presentationID += 1
         let panel = ensurePanel()
         model.presentation = presentation
         model.lang = lang
@@ -246,6 +248,8 @@ final class HUDController {
 
     /// Surface a mic/permission error in the HUD.
     func error(_ text: String) {
+        hideWork?.cancel(); hideWork = nil
+        presentationID += 1
         let panel = ensurePanel()
         model.phase = .error
         if !text.isEmpty { model.errorText = text }
@@ -269,15 +273,28 @@ final class HUDController {
     }
 
     private func scheduleHide(after delay: TimeInterval) {
-        let work = DispatchWorkItem { [weak self] in self?.fadeOut() }
+        let presentationID = presentationID
+        let work = DispatchWorkItem { [weak self] in self?.fadeOut(presentationID: presentationID) }
         hideWork = work
         DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
     }
 
-    private func fadeOut() {
-        guard let panel else { return }
+    private func fadeOut(presentationID: Int) {
+        guard presentationID == self.presentationID, let panel else { return }
         NSAnimationContext.runAnimationGroup({ $0.duration = 0.25; panel.animator().alphaValue = 0 },
-                                             completionHandler: { panel.orderOut(nil) })
+                                             completionHandler: { [weak self, weak panel] in
+            MainActor.assumeIsolated {
+                guard let self, let panel,
+                      presentationID == self.presentationID, panel === self.panel else { return }
+                panel.orderOut(nil)
+
+                // `orderOut` only hides the panel. Keeping its NSHostingView attached leaves
+                // SwiftUI's repeat-forever bars and TimelineView rendering off-screen forever.
+                // Release the view tree so those display updates stop while Murmur is idle.
+                panel.contentView = nil
+                self.panel = nil
+            }
+        })
     }
 
     private func ensurePanel() -> NSPanel {

--- a/Sources/Murmur/HUDOverlay.swift
+++ b/Sources/Murmur/HUDOverlay.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 @Observable
 final class HUDModel {
-    enum Phase { case listening, transcribing, error }
+    enum Phase: Equatable { case listening, transcribing, error }
     var phase: Phase = .listening
     var confirmed = ""
     var partial = ""
@@ -210,12 +210,81 @@ private extension View {
 // MARK: - Panel controller
 
 @MainActor
+protocol HUDHideScheduling {
+    func schedule(after delay: TimeInterval, action: @escaping @MainActor () -> Void) -> HUDCancellation
+}
+
+final class HUDCancellation {
+    private let action: () -> Void
+    private(set) var isCancelled = false
+
+    init(_ action: @escaping () -> Void) {
+        self.action = action
+    }
+
+    func cancel() {
+        guard !isCancelled else { return }
+        isCancelled = true
+        action()
+    }
+}
+
+@MainActor
+final class DispatchHUDHideScheduler: HUDHideScheduling {
+    func schedule(after delay: TimeInterval, action: @escaping @MainActor () -> Void) -> HUDCancellation {
+        let work = DispatchWorkItem {
+            MainActor.assumeIsolated { action() }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+        return HUDCancellation { work.cancel() }
+    }
+}
+
+@MainActor
+protocol HUDAnimating {
+    func show(_ panel: NSPanel)
+    func hide(_ panel: NSPanel, completion: @escaping @MainActor () -> Void)
+}
+
+@MainActor
+final class AppKitHUDAnimator: HUDAnimating {
+    func show(_ panel: NSPanel) {
+        panel.alphaValue = 0
+        panel.orderFrontRegardless()
+        NSAnimationContext.runAnimationGroup {
+            $0.duration = 0.18
+            panel.animator().alphaValue = 1
+        }
+    }
+
+    func hide(_ panel: NSPanel, completion: @escaping @MainActor () -> Void) {
+        NSAnimationContext.runAnimationGroup({
+            $0.duration = 0.25
+            panel.animator().alphaValue = 0
+        }, completionHandler: {
+            MainActor.assumeIsolated { completion() }
+        })
+    }
+}
+
+@MainActor
 final class HUDController {
-    private let model = HUDModel()
-    private var panel: NSPanel?
-    private var hideWork: DispatchWorkItem?
-    private var presentationID = 0
+    private(set) var model = HUDModel()
+    private(set) var panel: NSPanel?
+    private(set) var presentationID = 0
+    private var hideWork: HUDCancellation?
+    private let scheduler: any HUDHideScheduling
+    private let animator: any HUDAnimating
     private let size = NSSize(width: 940, height: 260)
+
+    convenience init() {
+        self.init(scheduler: DispatchHUDHideScheduler(), animator: AppKitHUDAnimator())
+    }
+
+    init(scheduler: any HUDHideScheduling, animator: any HUDAnimating) {
+        self.scheduler = scheduler
+        self.animator = animator
+    }
 
     /// Reveal the HUD for a new utterance. `interactive` (toggle mode) makes the
     /// panel accept clicks so the Stop button works.
@@ -232,9 +301,7 @@ final class HUDController {
         model.onStop = onStop
         panel.ignoresMouseEvents = !interactive
         position(panel)
-        panel.alphaValue = 0
-        panel.orderFrontRegardless()
-        NSAnimationContext.runAnimationGroup { $0.duration = 0.18; panel.animator().alphaValue = 1 }
+        animator.show(panel)
     }
 
     /// Live two-tier update.
@@ -255,9 +322,7 @@ final class HUDController {
         if !text.isEmpty { model.errorText = text }
         model.recording = false
         position(panel)
-        panel.alphaValue = 0
-        panel.orderFrontRegardless()
-        NSAnimationContext.runAnimationGroup { $0.duration = 0.18; panel.animator().alphaValue = 1 }
+        animator.show(panel)
         scheduleHide(after: 3.2)
     }
 
@@ -273,28 +338,27 @@ final class HUDController {
     }
 
     private func scheduleHide(after delay: TimeInterval) {
+        hideWork?.cancel()
         let presentationID = presentationID
-        let work = DispatchWorkItem { [weak self] in self?.fadeOut(presentationID: presentationID) }
-        hideWork = work
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+        hideWork = scheduler.schedule(after: delay) { [weak self] in
+            self?.fadeOut(presentationID: presentationID)
+        }
     }
 
     private func fadeOut(presentationID: Int) {
         guard presentationID == self.presentationID, let panel else { return }
-        NSAnimationContext.runAnimationGroup({ $0.duration = 0.25; panel.animator().alphaValue = 0 },
-                                             completionHandler: { [weak self, weak panel] in
-            MainActor.assumeIsolated {
-                guard let self, let panel,
-                      presentationID == self.presentationID, panel === self.panel else { return }
-                panel.orderOut(nil)
+        hideWork = nil
+        animator.hide(panel) { [weak self, weak panel] in
+            guard let self, let panel,
+                  presentationID == self.presentationID, panel === self.panel else { return }
+            panel.orderOut(nil)
 
-                // `orderOut` only hides the panel. Keeping its NSHostingView attached leaves
-                // SwiftUI's repeat-forever bars and TimelineView rendering off-screen forever.
-                // Release the view tree so those display updates stop while Murmur is idle.
-                panel.contentView = nil
-                self.panel = nil
-            }
-        })
+            // `orderOut` only hides the panel. Keeping its NSHostingView attached leaves
+            // SwiftUI's repeat-forever bars and TimelineView rendering off-screen forever.
+            // Release the view tree so those display updates stop while Murmur is idle.
+            panel.contentView = nil
+            self.panel = nil
+        }
     }
 
     private func ensurePanel() -> NSPanel {
@@ -305,9 +369,9 @@ final class HUDController {
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = false
+        panel.isFloatingPanel = true
         panel.level = .statusBar
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary, .ignoresCycle]
-        panel.isFloatingPanel = true
         panel.becomesKeyOnlyIfNeeded = true
         panel.hidesOnDeactivate = false
         panel.ignoresMouseEvents = true

--- a/Tests/MurmurTests/HUDControllerTests.swift
+++ b/Tests/MurmurTests/HUDControllerTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+@testable import Murmur
+
+@MainActor
+final class HUDControllerTests: XCTestCase {
+    func testBeginResetsModelAndConfiguresInteractivePanel() {
+        let (controller, _, animator) = makeHUDController()
+        defer { tearDownHUD(controller) }
+
+        controller.error("old error")
+        controller.update(confirmed: "old", partial: "text")
+        var stopped = false
+        controller.begin(presentation: true, lang: "fr", interactive: true) { stopped = true }
+
+        XCTAssertEqual(controller.model.phase, .listening)
+        XCTAssertEqual(controller.model.confirmed, "")
+        XCTAssertEqual(controller.model.partial, "")
+        XCTAssertEqual(controller.model.lang, "fr")
+        XCTAssertTrue(controller.model.presentation)
+        XCTAssertTrue(controller.model.recording)
+        XCTAssertTrue(controller.model.showStop)
+        XCTAssertFalse(controller.panel?.ignoresMouseEvents ?? true)
+        XCTAssertEqual(animator.shownPanels.count, 2)
+        controller.model.onStop()
+        XCTAssertTrue(stopped)
+    }
+
+    func testNonInteractiveBeginIgnoresMouseEvents() {
+        let (controller, _, _) = makeHUDController()
+        defer { tearDownHUD(controller) }
+
+        controller.begin(presentation: false, lang: "Auto")
+
+        XCTAssertTrue(controller.panel?.ignoresMouseEvents ?? false)
+        XCTAssertFalse(controller.model.showStop)
+    }
+
+    func testUpdateTransitionsBetweenListeningAndTranscribing() {
+        let (controller, _, _) = makeHUDController()
+        defer { tearDownHUD(controller) }
+        controller.begin(presentation: false, lang: "Auto")
+
+        controller.update(confirmed: "hello", partial: "wor")
+        XCTAssertEqual(controller.model.phase, .transcribing)
+        XCTAssertEqual(controller.model.confirmed, "hello")
+        XCTAssertEqual(controller.model.partial, "wor")
+
+        controller.update(confirmed: "", partial: "")
+        XCTAssertEqual(controller.model.phase, .listening)
+    }
+
+    func testUpdateDoesNotReplaceErrorPhase() {
+        let (controller, _, _) = makeHUDController()
+        defer { tearDownHUD(controller) }
+        controller.error("denied")
+
+        controller.update(confirmed: "ignored", partial: "update")
+
+        XCTAssertEqual(controller.model.phase, .error)
+        XCTAssertEqual(controller.model.confirmed, "ignored")
+        XCTAssertEqual(controller.model.partial, "update")
+    }
+
+    func testFinishSchedulesNormalAndPresentationDelays() {
+        let (normal, normalScheduler, _) = makeHUDController()
+        defer { tearDownHUD(normal) }
+        normal.begin(presentation: false, lang: "Auto", interactive: true)
+        normal.finish("final words")
+
+        XCTAssertEqual(normalScheduler.entries.last?.delay, 1.0)
+        XCTAssertEqual(normal.model.confirmed, "final words")
+        XCTAssertEqual(normal.model.partial, "")
+        XCTAssertEqual(normal.model.phase, .transcribing)
+        XCTAssertFalse(normal.model.recording)
+        XCTAssertFalse(normal.model.showStop)
+
+        let (presentation, presentationScheduler, _) = makeHUDController()
+        defer { tearDownHUD(presentation) }
+        presentation.begin(presentation: true, lang: "Auto")
+        presentation.finish("")
+        XCTAssertEqual(presentationScheduler.entries.last?.delay, 4.0)
+        XCTAssertEqual(presentation.model.phase, .listening)
+    }
+
+    func testFinishWithoutPanelIsIgnored() {
+        let (controller, scheduler, _) = makeHUDController()
+
+        controller.finish("orphan")
+
+        XCTAssertTrue(scheduler.entries.isEmpty)
+        XCTAssertEqual(controller.model.confirmed, "")
+    }
+
+    func testRepeatedFinishCancelsEarlierDeadline() {
+        let (controller, scheduler, _) = makeHUDController()
+        defer { tearDownHUD(controller) }
+        controller.begin(presentation: false, lang: "Auto")
+
+        controller.finish("first")
+        controller.finish("second")
+
+        XCTAssertEqual(scheduler.entries.count, 2)
+        XCTAssertTrue(scheduler.entries[0].cancellation.isCancelled)
+        XCTAssertFalse(scheduler.entries[1].cancellation.isCancelled)
+        scheduler.fire(0)
+        XCTAssertNotNil(controller.panel)
+    }
+
+    func testErrorSchedulesHideAndPreservesDefaultForEmptyMessage() {
+        let (controller, scheduler, _) = makeHUDController()
+        defer { tearDownHUD(controller) }
+
+        controller.error("")
+
+        XCTAssertEqual(controller.model.phase, .error)
+        XCTAssertEqual(controller.model.errorText, "Open Privacy in Settings →")
+        XCTAssertFalse(controller.model.recording)
+        XCTAssertEqual(scheduler.entries.last?.delay, 3.2)
+    }
+
+    func testBeginCancelsPendingHideAndInvalidatesItsAction() {
+        let (controller, scheduler, animator) = makeHUDController()
+        defer { tearDownHUD(controller) }
+        controller.error("denied")
+        let oldID = controller.presentationID
+
+        controller.begin(presentation: false, lang: "en")
+
+        XCTAssertTrue(scheduler.entries[0].cancellation.isCancelled)
+        XCTAssertGreaterThan(controller.presentationID, oldID)
+        scheduler.fire(0, evenIfCancelled: true)
+        XCTAssertTrue(animator.hiddenPanels.isEmpty)
+        XCTAssertNotNil(controller.panel?.contentView)
+    }
+
+    func testErrorCancelsPendingFinishAndInvalidatesItsAction() {
+        let (controller, scheduler, animator) = makeHUDController()
+        defer { tearDownHUD(controller) }
+        controller.begin(presentation: false, lang: "Auto")
+        controller.finish("done")
+
+        controller.error("denied")
+
+        XCTAssertTrue(scheduler.entries[0].cancellation.isCancelled)
+        XCTAssertEqual(scheduler.entries[1].delay, 3.2)
+        scheduler.fire(0, evenIfCancelled: true)
+        XCTAssertTrue(animator.hiddenPanels.isEmpty)
+        XCTAssertEqual(controller.model.phase, .error)
+    }
+
+    func testStaleFadeCompletionCannotTearDownRePresentedHUD() {
+        let (controller, scheduler, animator) = makeHUDController()
+        defer { tearDownHUD(controller) }
+        controller.begin(presentation: false, lang: "Auto")
+        controller.finish("first")
+        scheduler.fire(0)
+        let originalPanel = controller.panel
+
+        controller.begin(presentation: false, lang: "Auto")
+        animator.completeHide()
+
+        XCTAssertTrue(controller.panel === originalPanel)
+        XCTAssertNotNil(controller.panel?.contentView)
+        XCTAssertEqual(controller.model.phase, .listening)
+    }
+}

--- a/Tests/MurmurTests/HUDPanelIntegrationTests.swift
+++ b/Tests/MurmurTests/HUDPanelIntegrationTests.swift
@@ -1,0 +1,87 @@
+import AppKit
+import XCTest
+@testable import Murmur
+
+@MainActor
+final class HUDPanelIntegrationTests: XCTestCase {
+    func testPanelUsesExpectedNonActivatingOverlayConfiguration() throws {
+        let (controller, _, _) = makeHUDController()
+        defer { tearDownHUD(controller) }
+        controller.begin(presentation: false, lang: "Auto")
+
+        let panel = try XCTUnwrap(controller.panel)
+        XCTAssertTrue(panel.styleMask.contains(.nonactivatingPanel))
+        XCTAssertTrue(panel.styleMask.contains(.borderless))
+        XCTAssertFalse(panel.isOpaque)
+        XCTAssertEqual(panel.backgroundColor, .clear)
+        XCTAssertFalse(panel.hasShadow)
+        XCTAssertEqual(panel.level, .statusBar)
+        XCTAssertTrue(panel.collectionBehavior.contains(.canJoinAllSpaces))
+        XCTAssertTrue(panel.collectionBehavior.contains(.fullScreenAuxiliary))
+        XCTAssertTrue(panel.collectionBehavior.contains(.stationary))
+        XCTAssertTrue(panel.collectionBehavior.contains(.ignoresCycle))
+        XCTAssertTrue(panel.isFloatingPanel)
+        XCTAssertTrue(panel.becomesKeyOnlyIfNeeded)
+        XCTAssertFalse(panel.hidesOnDeactivate)
+    }
+
+    func testPanelHostsSwiftUIViewAtExpectedSize() throws {
+        let (controller, _, _) = makeHUDController()
+        defer { tearDownHUD(controller) }
+        controller.begin(presentation: false, lang: "Auto")
+
+        let panel = try XCTUnwrap(controller.panel)
+        let host = try XCTUnwrap(panel.contentView)
+        XCTAssertTrue(String(describing: type(of: host)).contains("NSHostingView"))
+        XCTAssertEqual(host.frame.size.width, 940, accuracy: 0.1)
+        XCTAssertEqual(host.frame.size.height, 260, accuracy: 0.1)
+        XCTAssertTrue(host.autoresizingMask.contains(.width))
+        XCTAssertTrue(host.autoresizingMask.contains(.height))
+    }
+
+    func testCompletedHideDestroysHostedViewAndReleasesPanel() {
+        let (controller, scheduler, animator) = makeHUDController()
+        controller.begin(presentation: false, lang: "Auto")
+        controller.finish("done")
+        let panel = controller.panel
+
+        scheduler.fire(0)
+        XCTAssertTrue(animator.hiddenPanels.first === panel)
+        XCTAssertNotNil(panel?.contentView)
+
+        animator.completeHide()
+
+        XCTAssertNil(panel?.contentView)
+        XCTAssertNil(controller.panel)
+    }
+
+    func testNextPresentationCreatesFreshPanelAndViewTreeAfterTeardown() {
+        let (controller, scheduler, animator) = makeHUDController()
+        controller.begin(presentation: false, lang: "Auto")
+        let firstPanel = controller.panel
+        let firstView = firstPanel?.contentView
+        controller.finish("done")
+        scheduler.fire(0)
+        animator.completeHide()
+
+        controller.begin(presentation: false, lang: "Auto")
+        defer { tearDownHUD(controller) }
+
+        XCTAssertFalse(controller.panel === firstPanel)
+        XCTAssertFalse(controller.panel?.contentView === firstView)
+        XCTAssertNotNil(controller.panel?.contentView)
+    }
+
+    func testProductionSchedulerStartsHideAfterDeadline() async {
+        let animator = ManualHUDAnimator()
+        let controller = HUDController(scheduler: DispatchHUDHideScheduler(), animator: animator)
+        defer { tearDownHUD(controller) }
+        controller.begin(presentation: false, lang: "Auto")
+        controller.finish("done")
+
+        let didStartHiding = await waitForHUDCondition { animator.hiddenPanels.count == 1 }
+        XCTAssertTrue(didStartHiding)
+        animator.completeHide()
+        XCTAssertNil(controller.panel)
+    }
+}

--- a/Tests/MurmurTests/HUDTestSupport.swift
+++ b/Tests/MurmurTests/HUDTestSupport.swift
@@ -1,0 +1,72 @@
+import AppKit
+@testable import Murmur
+
+@MainActor
+final class ManualHUDScheduler: HUDHideScheduling {
+    struct Entry {
+        let delay: TimeInterval
+        let action: @MainActor () -> Void
+        let cancellation: HUDCancellation
+    }
+
+    private(set) var entries: [Entry] = []
+
+    func schedule(after delay: TimeInterval,
+                  action: @escaping @MainActor () -> Void) -> HUDCancellation {
+        let cancellation = HUDCancellation {}
+        entries.append(Entry(delay: delay, action: action, cancellation: cancellation))
+        return cancellation
+    }
+
+    func fire(_ index: Int, evenIfCancelled: Bool = false) {
+        let entry = entries[index]
+        guard evenIfCancelled || !entry.cancellation.isCancelled else { return }
+        entry.action()
+    }
+}
+
+@MainActor
+final class ManualHUDAnimator: HUDAnimating {
+    private(set) var shownPanels: [NSPanel] = []
+    private(set) var hiddenPanels: [NSPanel] = []
+    private var hideCompletions: [@MainActor () -> Void] = []
+
+    func show(_ panel: NSPanel) {
+        panel.alphaValue = 1
+        shownPanels.append(panel)
+    }
+
+    func hide(_ panel: NSPanel, completion: @escaping @MainActor () -> Void) {
+        panel.alphaValue = 0
+        hiddenPanels.append(panel)
+        hideCompletions.append(completion)
+    }
+
+    func completeHide(_ index: Int = 0) {
+        hideCompletions[index]()
+    }
+}
+
+@MainActor
+func makeHUDController() -> (HUDController, ManualHUDScheduler, ManualHUDAnimator) {
+    let scheduler = ManualHUDScheduler()
+    let animator = ManualHUDAnimator()
+    return (HUDController(scheduler: scheduler, animator: animator), scheduler, animator)
+}
+
+@MainActor
+func tearDownHUD(_ controller: HUDController) {
+    controller.panel?.orderOut(nil)
+    controller.panel?.contentView = nil
+}
+
+@MainActor
+func waitForHUDCondition(timeout: Duration = .seconds(3),
+                         _ condition: () -> Bool) async -> Bool {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: timeout)
+    while !condition(), clock.now < deadline {
+        try? await Task.sleep(for: .milliseconds(20))
+    }
+    return condition()
+}


### PR DESCRIPTION
## What changed

- Release the HUD's SwiftUI view tree after its fade-out completes.
- Track each HUD presentation so a stale fade completion cannot tear down a newly reopened panel.

## Why

Hiding the `NSPanel` with `orderOut` left its `NSHostingView` attached. The hidden HUD therefore retained its repeat-forever SwiftUI animations and `TimelineView`, continuing off-screen rendering while Murmur was idle and causing sustained CPU usage.

The panel is still reused during an active presentation, but after the matching fade completes its content view and controller reference are released. The next presentation recreates them normally.

## Impact

Murmur should return to idle CPU after the HUD disappears, without a stale animation completion closing a newer HUD presentation.

## Validation

- Unsigned arm64 Release build succeeded.
- MurmurKit test suite passed: 7/7 tests, 0 failures.
- `git diff --check` passed.
- A clean restart of the currently installed, unpatched app established an idle baseline of 0% CPU.

The existing automated tests cover onboarding flow only; they do not exercise HUD lifecycle or CPU behavior. A patched, signed end-to-end dictation → fade → idle CPU benchmark has not been run because maintainer signing credentials are unavailable. This PR is therefore intentionally left in draft.

Fixes #3
